### PR TITLE
Log unhandled exceptions

### DIFF
--- a/autoreply.py
+++ b/autoreply.py
@@ -291,4 +291,9 @@ def main():
 
 
 if __name__ == '__main__':
-   main()
+  try:
+    main()
+  except BaseException as exc:
+    import traceback
+    log("Unhandled exception: %s\n%s" % (exc.__class__.__name__, traceback.format_exc()))
+    raise


### PR DESCRIPTION
Sometimes things simply go wrong :D When autoreply crashes, Postfix logs the error message, but autoreply's own log shows nothing... This PR logs all unhandled exceptions, so you don't have to cross-check both logs