### PR TITLE
Remove CR/LFs from subject

### DIFF
--- a/autoreply.py
+++ b/autoreply.py
@@ -210,7 +210,7 @@ def autoreply(sender, recipients, original_msg, original_id):
               log(str(body) + ' doesn\'t exist. Check path.')
 
           # Replace placeholders
-          subject = subject.replace("{ORIGINAL_SUBJECT}", original_msg["Subject"])
+          subject = subject.replace("{ORIGINAL_SUBJECT}", original_msg["Subject"]).replace("\r", "").replace("\n", "")
           body = body.replace("{ORIGINAL_DESTINATION}", email)
 
           message = generate_email(


### PR DESCRIPTION
Our mailserver received a weird email containing a newline in the subject header :frowning:
This PR removes them, since the `email.Message` Python class wouldn't accept it